### PR TITLE
[RFR] - removed contentmarkup.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 cache/*
 log/*
 vendor/*
+bundle/ToolbarBundle/*
 
 bootstrap.yml
 composer.lock

--- a/repository/Config/contentmarkup.yml
+++ b/repository/Config/contentmarkup.yml
@@ -1,7 +1,0 @@
-# Content makup (this is deprecated and unused since version 0.12)
-
-contentmarkup:
-    contentclass: bb5-content
-    draggableclass: bb5-draggable-item
-    resizableclass: bb5-resizable-item
-    droppableclass: bb5-droppable-item


### PR DESCRIPTION
``contentmarkup.yml`` is used by ``backbee/backbee`` version <= 0.11 and not anymore from ``backbee\backbee`` 0.12.
Also added bundle/ToolbarBundle/* as folder to ignore (this is really useful on dev environement).