### PR TITLE
[RFR] - Improved the installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,10 @@ cache/*
 log/*
 vendor/*
 bundle/ToolbarBundle/*
+repository/Resources/toolbar/*
 
 bootstrap.yml
 composer.lock
 doctrine.yml
+services.yml
 sites.yml

--- a/Application.php
+++ b/Application.php
@@ -25,6 +25,7 @@ use BackBee\BBApplication;
 
 /**
  * @author e.chau <eric.chau@lp-digital.fr>
+ * @author Mickaël Andrieu <mickael.andrieu@lp-digital.fr>
  */
 class Application extends BBApplication
 {
@@ -34,5 +35,16 @@ class Application extends BBApplication
     public function getBaseDir()
     {
         return __DIR__;
+    }
+
+    /**
+     * Check if the CMS is installed
+     */
+    public function isIntalled()
+    {
+        return is_file($this->getBBConfigDir().DIRECTORY_SEPARATOR.'sites.yml')
+            && is_file($this->getBBConfigDir().DIRECTORY_SEPARATOR.'doctrine.yml')
+            && is_file($this->getBBConfigDir().DIRECTORY_SEPARATOR.'bootstrap.yml')
+        ;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,24 @@
             "email": "eric.chau@lp-digital.fr"
         }
     ],
+     "repositories": [
+        {
+            "type":"package",
+            "package": {
+                "name": "backbee/client-js",
+                "description": "Javascript client for BackBee CMS",
+                "version": "dev-master",
+                "dist": {
+                    "url": "https://github.com/backbee/BbCoreJs/archive/master.zip",
+                    "type": "zip"
+                }
+            }
+        }
+    ],
     "require": {
         "php": ">=5.4.0",
         "backbee/backbee": "dev-master",
+        "backbee/client-js": "dev-master",
         "backbee/script-handler": "dev-master",
         "backbee/demo-bundle": "dev-master",
         "backbee/toolbar-bundle": "dev-master"
@@ -29,7 +44,8 @@
             "BackBee\\Standard\\Composer\\ScriptHandler::buildBootstrap",
             "BackBee\\Standard\\Composer\\ScriptHandler::buildDoctrineConfig",
             "BackBee\\Standard\\Composer\\ScriptHandler::buildServicesConfig",
-            "BackBee\\Standard\\Composer\\ScriptHandler::clearBackBeeInstall"
+            "BackBee\\Standard\\Composer\\ScriptHandler::clearBackBeeInstall",
+            "BackBee\\Standard\\Composer\\ScriptHandler::moveClient"
         ],
         "post-update-cmd": [
             "BackBee\\Standard\\Composer\\ScriptHandler::buildParameters",
@@ -37,7 +53,8 @@
             "BackBee\\Standard\\Composer\\ScriptHandler::buildBootstrap",
             "BackBee\\Standard\\Composer\\ScriptHandler::buildDoctrineConfig",
             "BackBee\\Standard\\Composer\\ScriptHandler::buildServicesConfig",
-            "BackBee\\Standard\\Composer\\ScriptHandler::clearBackBeeInstall"
+            "BackBee\\Standard\\Composer\\ScriptHandler::clearBackBeeInstall",
+            "BackBee\\Standard\\Composer\\ScriptHandler::moveClient"
         ]
     },
     "extra": {

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Redirecting...</title>
+    <meta http-equiv="Refresh" content="0; url=web">
+</head>
+<body>
+Redirecting...
+</body>
+</html>

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,26 @@
 <?php
 
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee Standard Edition.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee Standard Edition is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee Standard Edition. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 if (!is_file($autoloadFile = __DIR__.'/../vendor/autoload.php')) {
+    echo('<p>BackBee could not find composer autoloader. Did you install and run "composer install --dev" command?</p>');
     throw new \LogicException('Could not find autoload.php in vendor/. Did you run "composer install --dev"?');
 }
 
@@ -10,4 +30,13 @@ $context = null;
 $environment = null;
 
 $application = new \BackBee\Standard\Application($context, $environment);
-$application->start();
+
+/**
+ * After installation you can delete this check
+ * and only keep $application->start();
+ */
+if ($application->isIntalled()) {
+    $application->start();
+}else {
+    header('Location: install.php');
+}


### PR DESCRIPTION
For a complete description, see https://github.com/backbee/backbee-standard/issues/99

I have updated the ComposerHandler and the ToolbarBundle in order to make this happens.

Now, the toolbar assets will be located in ``repository/Resources/toolbar`` folder, allow developpers to customize the toolbar.

This is **not** the best way to do this, this is a non BC way to have a complete installer for now.

Somes features added:

* the integration has been improved, with Bootstrap 3.2 rules, placeholder and so on;
* we have to create admin account user, "admin/admin" was the worst idea ever :-) ;
* the password is no more encoded using md5() but the password encoder selected for the BackBee User, which can be overrided in yaml configuration;
* the CMS application have a ``isInstalled()`` helper function: if the user go to the root directory of the CMS, he is redirected to the web folder, and then, if the CMS is not installed, he is redirected to the Installation process.
* Removed some useless web server rules, regarding to the move of bbcorejs to the Resources folder of the application
* Refactored a little bit the installation process, with a nice addition of the Symfony Debug component (far better than a blank page)
* Added some comments to help developper to understand this installer.

notice: the repository for BbCoreJs is called "client-js" for now, I'm waiting for a builtin distribution of BbCoreJs the next week (with a composer.json file) /c @ndufreche ;)