### PR TITLE
[RFR] [repository] added Traits\MediaImageNameTrait

### DIFF
--- a/repository/ClassContent/Media/Image.yml
+++ b/repository/ClassContent/Media/Image.yml
@@ -4,6 +4,7 @@ Image:
         description: A media image
         labelized-by: title->value
         category: [Media]
+    traits: [BackBee\Traits\MediaImageNameTrait]
     elements:
         title:
             type: BackBee\ClassContent\Element\Text

--- a/repository/Traits/MediaImageNameTrait.php
+++ b/repository/Traits/MediaImageNameTrait.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Traits;
+
+/**
+ * @author Eric Chau <eric.chau@lp-digital.fr>
+ */
+trait MediaImageNameTrait
+{
+    /**
+     * @see \BackBee\ClassContent\AbstractClassContent::getImageName
+     */
+    public function getImageName()
+    {
+        $imageName =  $this->getDefaultImageName();
+        if (null !== $this->image) {
+            $imageName = '/'.$this->image->path;
+        }
+
+        return $imageName;
+    }
+}


### PR DESCRIPTION
``BackBee\Traits\MediaImageNameTrait`` is added to override ``BackBee\ClassContent\AbstractClassContent::getImageName`` to return real image name if it is contributed, else the default thumbnail.