### PR TITLE
[RFR] [public] updated install.php to clean up container dumps after installation to prevent errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ cache/*
 log/*
 vendor/*
 bundle/ToolbarBundle/*
-repository/Resources/toolbar/*
+repository/Resources/toolbar/
 
 bootstrap.yml
 composer.lock


### PR DESCRIPTION
This PR aim to solve issue reported by @fkroockmann: [backbee/backbee issue 329](https://github.com/backbee/BackBee/issues/329)

The source of the problem still not clearly identified yet but it appears when we run install of BackBee Standard Edition with ``debug`` setted to false. This PR brings a fix to it by removing every dump files of application dependency injection container on last step of the install wizard.