### PR TITLE
[repository] updated Traits\MediaImageNameTrait to override image name's only if its path is valid

### DIFF
--- a/repository/Traits/MediaImageNameTrait.php
+++ b/repository/Traits/MediaImageNameTrait.php
@@ -34,7 +34,7 @@ trait MediaImageNameTrait
     public function getImageName()
     {
         $imageName =  $this->getDefaultImageName();
-        if (null !== $this->image) {
+        if (null !== $this->image && !empty($this->image->path)) {
             $imageName = '/'.$this->image->path;
         }
 


### PR DESCRIPTION
Currently, ClassContent REST API returns an invalid image's URL for a newly created ``BackBee\ClassContent\Media\Image``. This PR aims to fix it and override image name only if its path is valid, else return the default ClassContent's name.