### PR TITLE
[repository] fixed wrong URL of favicon

### DIFF
--- a/repository/Templates/scripts/partials/header-head.twig
+++ b/repository/Templates/scripts/partials/header-head.twig
@@ -8,7 +8,7 @@
     <link rel="apple-touch-icon-precomposed" sizes="72x72" href="{{ this.getUri('/img/apple-touch-icon-72x72.png') }}">
     <link rel="apple-touch-icon-precomposed" sizes="114x114" href="{{ this.getUri('/img/apple-touch-icon-114x114.png') }}">
 
-    <link rel="shortcut icon" href="{{ this.getUri('/favicon.png') }}">
+    <link rel="shortcut icon" href="{{ this.getUri('/favicon.ico') }}">
 
     {% include 'partials/header-css.twig' %}
 </head>


### PR DESCRIPTION
Requested favicon with wrong extension, ``.png`` instead of ``.ico`` so it caused an error 500.