### PR TITLE
[repository] updated 'navbar' helper to use right classname

### DIFF
--- a/repository/Templates/helpers/navbar.php
+++ b/repository/Templates/helpers/navbar.php
@@ -27,8 +27,8 @@ class navbar extends AbstractHelper
                     ];
 
                     $articles[$page->getUid()] = $application->getEntityManager()
-                        ->getRepository('BackBee\ClassContent\AClassContent')
-                        ->getSelection($selector, false, true, 0, 3, true, false, ['BackBee\ClassContent\article'])
+                        ->getRepository('BackBee\ClassContent\AbstractClassContent')
+                        ->getSelection($selector, false, true, 0, 3, true, false, ['BackBee\ClassContent\Article'])
                     ;
                 }
             }


### PR DESCRIPTION
``navbar`` helper still has reference to ``BackBee\ClassContent\AClassContent`` and ``BackBee\ClassContent\article`` which are out of date. Exception is visible when you put a page online and visible in menu.