### PR TITLE
[repository] updated Article classcontent and Media\Image classcontent views

### DIFF
--- a/repository/Templates/scripts/Article.twig
+++ b/repository/Templates/scripts/Article.twig
@@ -46,40 +46,6 @@
 
     {{ this.render(body)|raw }}
 
-    <!-- article-author -->
-    <div class="row article-footer links-color" id="article-author">
-        <div class="col-md-6">
-            <div class="article-author-id" itemprop="author">
-                <figure class="figure block-left">
-                    <img src="{{ this.getUri('ressources/img/media-avatar-01.png') }}" alt="Lorem ipsum" itemprop="image">
-                </figure>
-
-                <!-- -->
-                <div class="float-reflow">
-                    <p><a href="#" rel="author" itemprop="">{{ signature }}</a> <i itemprop="jobTitle">News reporter</i></p>
-                    <meta itemprop="interactionCount" content="UserTweets:1203">
-                    <meta itemprop="interactionCount" content="UserComments:78">
-                    <p>Follow him on&nbsp;:</p>
-                    <ul class="list-inline">
-                        <li><a href="#" class="btn btn-default btn-sm" title="Go to his Google+" target="_blank" rel="author me"><i class="fa fa-google-plus"></i><i class="sr-only">{{ signature }} on Google+</i></a></li>
-                        <li><a href="#" class="btn btn-default btn-sm" title="Go to his Twitter" target="_blank" rel="me"><i class="fa fa-twitter"></i><i class="sr-only">{{ signature }} on Twitter</i></a></li>
-                        <li><a href="#" class="btn btn-default btn-sm" title="Go to his LinkedIn" target="_blank" rel="me"><i class="fa fa-linkedin"></i><i class="sr-only">{{ signature }} on LinkedIn</i></a></li>
-                        <li><a href="#" class="btn btn-default btn-sm" title="Send an email" target="_blank" rel="me"><i class="fa fa-envelope-o"></i><i class="sr-only">Send an email to {{ signature }}</i></a></li>
-                    </ul>
-                </div>
-            </div>
-        </div>
-
-        <div class="col-md-6">
-            <div class="article-author-production">
-                <p><i>Last article</i></p>
-                <p><a href="#" itemprop="url"><i class="fa fa-angle-right"></i>&nbsp;Some random article title here...</a></p>
-                <p>Rated&nbsp;: 90/100 (35 votes)</p>
-            </div>
-        </div>
-
-    </div>
-
     <section class="bloc">
         {{ this.render(related)|raw }}
     </section>

--- a/repository/Templates/scripts/Media/Image.twig
+++ b/repository/Templates/scripts/Media/Image.twig
@@ -1,7 +1,7 @@
 {% if this.isBBUser() == true or image.path != '' %}
 	<figure {{ this.bbcontent(null, {'class': 'figure'})|raw }}>
 		<img {{ this.bbcontent(image)|raw }}
-			src="{{ this.getImageUrl(image.path)|raw }}"
+			src="{{ image.path ? this.getImageUrl(image.path)|raw : '' }}"
 			alt="{{ title }}" style="width: 100%" itemprop="contentURL">
 
 	    <figcaption class="figure-caption" itemprop="description">


### PR DESCRIPTION
Updated ``BackBee\ClassContent\Article`` twig template to remove the author block (which requested invalid user avatar url).

Updated ``BackBee\ClassContent\Media\Image`` to generate image's url if only the path is not empty.

These two upgrades fix error 500.