### PR TITLE
[repository] overrode Media\Image::jsonSerialize to add extra parameters

### DIFF
--- a/repository/ClassContent/Media/Image.yml
+++ b/repository/ClassContent/Media/Image.yml
@@ -4,7 +4,7 @@ Image:
         description: A media image
         labelized-by: title->value
         category: [Media]
-    traits: [BackBee\Traits\MediaImageNameTrait]
+    traits: [BackBee\Traits\MediaImageNameTrait,BackBee\Traits\MediaImageJsonSerializeTrait]
     elements:
         title:
             type: BackBee\ClassContent\Element\Text

--- a/repository/Traits/MediaImageJsonSerializeTrait.php
+++ b/repository/Traits/MediaImageJsonSerializeTrait.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Charles Rouillon <charles.rouillon@lp-digital.fr>
+ */
+
+namespace BackBee\Traits;
+
+use BackBee\ClassContent\AbstractContent;
+
+/**
+ * @author Eric Chau <eric.chau@lp-digital.fr>
+ */
+trait MediaImageJsonSerializeTrait
+{
+    /**
+     * @see AbstractContent::jsonSerialize
+     */
+    public function jsonSerialize($format = AbstractContent::JSON_DEFAULT_FORMAT)
+    {
+        $data = parent::jsonSerialize($format);
+
+        if (AbstractContent::JSON_DEFAULT_FORMAT === $format || AbstractContent::JSON_CONCISE_FORMAT === $format) {
+            $imageExtraData = null !== $this->image ? $this->image->jsonSerialize($format)['extra'] : [];
+            $data['extra'] = array_merge($data['extra'], $imageExtraData);
+        }
+
+        return $data;
+    }
+}


### PR DESCRIPTION
Updated ``BackBee\ClassContent\Media\Image::jsonSerialize`` with ``BackBee\Traits\MediaImageJsonSerializeTrait`` to add its image extra parameters as its own extra parameters.

This PR aims to resolve [backbee/bb-core-js issue #414](https://github.com/backbee/BbCoreJs/issues/414).

This PR should not be merged until [backbee/backbee PR #361](https://github.com/backbee/BackBee/pull/361) is merged.