### PR TITLE
Re-allow Http port selection (vagrant/virtualisation uses)

### DIFF
--- a/public/install.php
+++ b/public/install.php
@@ -283,7 +283,11 @@ switch ($step) {
 
             $em = $application->getEntityManager();
             $pagebuilder = $application->getContainer()->get('pagebuilder');
-            $domain = parse_url($_POST['domain'],PHP_URL_HOST);
+            $host = parse_url($_POST['domain'],PHP_URL_HOST);
+            $port = parse_url($_POST['domain'], PHP_URL_PORT);
+
+            $domain = $host.(empty($port) ? '' : ':'.$port);
+
             $sites = [
                 \BackBee\Utils\String::urlize($_POST['site_name']) => [
                     'label'  => $_POST['site_name'],


### PR DESCRIPTION
With the new url filter, ports are not saved form server side.

So I've added a new filter to get the port from the form client data.

* if port is available, we concatenate to the host.