### PR TITLE
Updated Article/Related yml file to disable it from draggable classcontent

### DIFF
--- a/repository/ClassContent/Article/Related.yml
+++ b/repository/ClassContent/Article/Related.yml
@@ -3,7 +3,7 @@ Related:
   properties:
     name: Linked articles
     description: "A block that displays linked articles. Contains: ContentSet, Article"
-    category: [Article]
+    category: [!Article]
     clonemode: inherited
   parameters:
     rendermode: related


### PR DESCRIPTION
``Article/Related`` content must not be a standalone draggable content in front so we have to hide it.