### PR TITLE
[Locked] Register commands in application

### DIFF
--- a/backbee
+++ b/backbee
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Display the BackBee console
-./vendor/bin/backbee --app='\BackBee\Standard\Application' $@
+./vendor/bin/backbee --app='\BackBee\Standard\Application' "$@"

--- a/repository/Command/WelcomeCommand.php
+++ b/repository/Command/WelcomeCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright (c) 2011-2015 Lp digital system
+ *
+ * This file is part of BackBee Standard Edition.
+ *
+ * BackBee is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * BackBee Standard Edition is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with BackBee Standard Edition. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace BackBee\Standard\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use BackBee\Console\AbstractCommand;
+
+/**
+ * Welcome command
+ * @author Mickaël Andrieu <mickael.andrieu@lp-digital.fr>
+ */
+class WelcomeCommand extends AbstractCommand
+{
+    protected function configure()
+    {
+        $this
+            ->setName('demo:welcome')
+            ->setDescription('Welcome someone')
+            ->addArgument(
+                'name',
+                InputArgument::OPTIONAL,
+                'Who do you want to welcome?'
+            )
+            ->addOption(
+                'yell',
+                null,
+                InputOption::VALUE_NONE,
+                'If set, the message will yell in uppercase letters'
+            )
+            ->setHelp(<<<EOF
+The <info>%command.name%</info> command can welcome someone.
+With the option ``yell``, the message will be displayed in uppercase letters.
+EOF
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    { 
+        $text = 'Welcome '.$input->getArgument('name');
+
+        if ($input->getOption('yell')) {
+            $text = strtoupper($text);
+        }
+
+        $output->writeln($text);
+    }
+}


### PR DESCRIPTION
Hi,

we can create our owns commands in ``repository/Commands`` folder.

Also, I have added a sample command to test this feature which is our version of Symfony GreetCommand.

Notice I have updated backbee binary: $@ need to be quoted to allow console to accept string argument with spaces (https://github.com/symfony/symfony/issues/11205)

Assuming we have a Welcome2Command in ``repository/context``, see some captures:
* **Commands without any context**
![without-context](https://cloud.githubusercontent.com/assets/1247388/8183244/03669cc2-1437-11e5-9e9c-9635b592494d.png)

* **Commands with context "context"**
```bash
➜  backbee-standard git:(register-commands-in-application) ✗ ./backbee --context=context
```

![with-context](https://cloud.githubusercontent.com/assets/1247388/8183285/384edf62-1437-11e5-94c4-8f5762e60a75.png)
