### PR TITLE
Removed SQLite option from Web installer

### DIFF
--- a/public/install.php
+++ b/public/install.php
@@ -874,7 +874,6 @@ function addAcl($objectIdentity, $aclProvider, $securityIdentity, $rights)
                                     <select class="form-control" name="driver" id="driver">
                                         <option value="pdo_mysql" selected>MySQL</option>
                                         <option value="pdo_pgsql">PostgreSQL</option>
-                                        <option value="pdo_sqlite">SQLite</option>
                                     </select>
                                 </div>
 


### PR DESCRIPTION
For now, this won't work as expected. The best we can do for now is remove this option and re-introduce it later.

ping @eric-chau 