### PR TITLE
removed js toolbar from repository

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
             "BackBee\\Standard\\Composer\\ScriptHandler::buildBootstrap",
             "BackBee\\Standard\\Composer\\ScriptHandler::buildDoctrineConfig",
             "BackBee\\Standard\\Composer\\ScriptHandler::buildServicesConfig",
-            "BackBee\\Standard\\Composer\\ScriptHandler::clearBackBeeInstall",
-            "BackBee\\Standard\\Composer\\ScriptHandler::moveClient"
+            "BackBee\\Standard\\Composer\\ScriptHandler::clearBackBeeInstall"
         ],
         "post-update-cmd": [
             "BackBee\\Standard\\Composer\\ScriptHandler::buildParameters",
@@ -40,8 +39,7 @@
             "BackBee\\Standard\\Composer\\ScriptHandler::buildBootstrap",
             "BackBee\\Standard\\Composer\\ScriptHandler::buildDoctrineConfig",
             "BackBee\\Standard\\Composer\\ScriptHandler::buildServicesConfig",
-            "BackBee\\Standard\\Composer\\ScriptHandler::clearBackBeeInstall",
-            "BackBee\\Standard\\Composer\\ScriptHandler::moveClient"
+            "BackBee\\Standard\\Composer\\ScriptHandler::clearBackBeeInstall"
         ]
     },
     "extra": {

--- a/public/install.php
+++ b/public/install.php
@@ -932,6 +932,11 @@ server {
     error_log /var/log/nginx/<?php echo \BackBee\Utils\StringUtils::urlize($site['label']); ?>.error.log;
     access_log /var/log/nginx/<?php echo \BackBee\Utils\StringUtils::urlize($site['label']); ?>.access.log;
 
+    location ~ /resources/toolbar/(.*) {
+        alias <?php echo dirname(__DIR__) . '/'; ?>;
+        try_files /vendor/backbee/bb-core-js/$1 @rewriteapp;
+    }
+
     location ~ /resources/(.*) {
         alias <?php echo dirname(__DIR__) . '/'; ?>;
         try_files /repository/Resources/$1 /vendor/backbee/backbee/Resources/$1 @rewriteapp;
@@ -969,6 +974,9 @@ server {
         Order allow,deny
         allow from all
     &lt;/Directory&gt;
+
+    RewriteCond %{DOCUMENT_ROOT}/../vendor/backbee/bb-core-js/$1 -f
+    RewriteRule ^/resources/toolbar/(.*)$ %{DOCUMENT_ROOT}/../vendor/backbee/bb-core-js/$1 [L]
 
     RewriteCond %{DOCUMENT_ROOT}/../repository/Resources/$1 -f
     RewriteRule ^/resources/(.*)$ %{DOCUMENT_ROOT}/../repository/Resources/$1 [L]


### PR DESCRIPTION
Moving `toolbar` into `repository/Resources/` folder is not required anymore. Virtualhost for apache2 and nginx have been updated. And even if there is no configured virtualhost, `BackBee` is able to retrieve toolbar files thanks to `ToolbarBundle` [PR #67](https://github.com/backbee/ToolbarBundle/pull/67).