### PR TITLE
updated listeners to follow best practices

### DIFF
--- a/repository/Config/events.yml
+++ b/repository/Config/events.yml
@@ -2,13 +2,13 @@ block.autoblock.render:
   listeners:
     - [BackBee\Event\Listener\AutoblockListener, onRender]
 
-social.facebook.prerender:
+social.facebook.render:
   listeners:
-    - [BackBee\Event\Listener\SocialListener, onPreRenderFacebook]
+    - [BackBee\Event\Listener\SocialListener, onRenderFacebook]
 
-social.twitter.prerender:
+social.twitter.render:
   listeners:
-    - [BackBee\Event\Listener\SocialListener, onPreRenderTwitter]
+    - [BackBee\Event\Listener\SocialListener, onRenderTwitter]
 
 article.article.render:
   listeners:
@@ -17,7 +17,7 @@ article.article.render:
 article.quote.render:
   listeners:
     - [BackBee\Event\Listener\QuoteListener, onRender]
-    
+
 home.slider.render:
     listeners:
         - [BackBee\Event\Listener\SliderListener, onRender]

--- a/repository/Listener/ArticleListener.php
+++ b/repository/Listener/ArticleListener.php
@@ -21,21 +21,20 @@
 
 namespace BackBee\Event\Listener;
 
-use BackBee\Event\Event;
+use BackBee\Renderer\Event\RendererEvent;
 
 /**
  * Article Listener
  *
  * @author f.kroockmann <florian.kroockmann@lp-digital.fr>
  */
-class ArticleListener extends Event
+class ArticleListener
 {
-    public static function onRender(Event $event)
+    public static function onRender(RendererEvent $event)
     {
-        $renderer = $event->getEventArgs();
-        $application = $event->getDispatcher()->getApplication();
+        $renderer = $event->getRenderer();
 
-        $content = $renderer->getObject();
+        $content = $event->getTarget();
         $tag = null;
         $url = '#';
         $mainNode = $content->getMainNode();

--- a/repository/Listener/QuoteListener.php
+++ b/repository/Listener/QuoteListener.php
@@ -21,22 +21,21 @@
 
 namespace BackBee\Event\Listener;
 
-use BackBee\Event\Event;
+use BackBee\Renderer\Event\RendererEvent;
 
 /**
  * Quote Listener
  *
  * @author f.kroockmann <florian.kroockmann@lp-digital.fr>
  */
-class QuoteListener extends Event
+class QuoteListener
 {
-    public static function onRender(Event $event)
+    public static function onRender(RendererEvent $event)
     {
-        $renderer = $event->getEventArgs();
-        $application = $event->getDispatcher()->getApplication();
-        $em = $application->getEntityManager();
+        $renderer = $event->getRenderer();
+        $em = $event->getApplication()->getEntityManager();
 
-        $content = $renderer->getObject();
+        $content = $event->getTarget();
 
         $links = $content->getParamValue('link');
         $link = [

--- a/repository/Listener/SocialListener.php
+++ b/repository/Listener/SocialListener.php
@@ -22,8 +22,7 @@
 namespace BackBee\Event\Listener;
 
 use BackBee\ClassContent\Social\Twitter;
-use BackBee\Event\Event;
-use Doctrine\ORM\Event\PreUpdateEventArgs;
+use BackBee\Renderer\Event\RendererEvent;
 
 /**
  * Social network Listener
@@ -31,20 +30,20 @@ use Doctrine\ORM\Event\PreUpdateEventArgs;
  * @author f.kroockmann <florian.kroockmann@lp-digital.fr>
  * @author Mickaël Andrieu <mickael.andrieu@lp-digital.fr>
  */
-class SocialListener extends Event
+class SocialListener
 {
     const WIDGET_API_URL = 'https://twitter.com/settings/widgets/';
 
     private static $application;
 
-    public static function onPreRenderFacebook(Event $event)
+    public static function onRenderFacebook(RendererEvent $event)
     {
-        $renderer = $event->getEventArgs();
-        self::$application = $event->getDispatcher()->getApplication();
+        $renderer = $event->getRenderer();
+        self::$application = $event->getApplication();
 
         $config = self::getSocialConfig('facebook');
 
-        $content = $renderer->getObject();
+        $content = $event->getTarget();
 
         $link = $content->getParamValue('link');
         if (empty($link)) {
@@ -62,7 +61,7 @@ class SocialListener extends Event
                  ->assign('height', $content->getParamValue('height'));
     }
 
-    public static function onPreRenderTwitter(Event $event)
+    public static function onRenderTwitter(RendererEvent $event)
     {
         $renderer = $event->getEventArgs();
         self::$application = $event->getDispatcher()->getApplication();


### PR DESCRIPTION
- Listener must not extend `BackBee\Event\Event`.
- Must use `Renderer\Event\RendererEvent` for events dispatched by `Renderer`.
- Listen to `.render` event instead of `.prerender` event anytime you can. `.prerender` is reserved for cache management.