### PR TITLE
[Install] Fix install requirements compatibility with php 5.4 syntax

### DIFF
--- a/public/BackBeeRequirements.php
+++ b/public/BackBeeRequirements.php
@@ -140,9 +140,11 @@ class BackBeeRequirements
             'Your version of PHP was compiled with <em>--disable-tokenizer</em>, please recompile it without this option.'
         );
 
+        $dateTimeZone = ini_get('date.timezone');
+
         $requirements[] = new Requirement(
             false,
-            empty(ini_get('date.timezone')),
+            empty($dateTimeZone),
             'Default timezone set',
             'We strongly recommend you to set a default timezone<br/>(see <a href="http://php.net/manual/en/datetime.configuration.php#ini.date.timezone" target="_blank">http://php.net/manual/en/datetime.configuration.php#ini.date.timezone</a>).',
             false,


### PR DESCRIPTION
In the install requirements process there is a piece of code that is not compatible with the required PHP 5.4 syntax.

Thanks a lot for your feedback.